### PR TITLE
Add Subscribers.Stream and fix cancellation in custom subscriptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: swift build -v
+    - name: Run tests
+      run: swift test -v

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/shareup/synchronized.git",
         "state": {
           "branch": null,
-          "revision": "e8bbab660d61b4f78fd94c3640f1a03886c326ea",
-          "version": "2.1.0"
+          "revision": "3843da8ff2af3e6c3fc30853ed473ba7630e7cfe",
+          "version": "2.2.0"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package(
         .package(
             name: "Synchronized",
             url: "https://github.com/shareup/synchronized.git",
-            from: "2.1.0"
+            from: "2.2.0"
         )
     ],
     targets: [

--- a/Sources/CombineExtensions/InputStreamPublisher.swift
+++ b/Sources/CombineExtensions/InputStreamPublisher.swift
@@ -96,6 +96,7 @@ private final class InputStreamSubscription<S: Subscriber>: Subscription
     }
 
     func cancel() {
+        lock.locked { subscriber = nil }
         complete(with: .finished)
     }
 

--- a/Sources/CombineExtensions/ReduceLatest.swift
+++ b/Sources/CombineExtensions/ReduceLatest.swift
@@ -199,6 +199,7 @@ private final class ReduceLatestSubscription<Subscriber, A, B, C, D, Output, Fai
     }
 
     func cancel() {
+        lock.locked { subscriber = nil }
         complete(with: .finished)
     }
 

--- a/Sources/CombineExtensions/StreamSubscriber.swift
+++ b/Sources/CombineExtensions/StreamSubscriber.swift
@@ -1,0 +1,178 @@
+import Combine
+import Foundation
+import Synchronized
+
+public extension Publisher where Output == [UInt8], Failure == Error {
+    func stream(
+        toBuffer buffer: UnsafeMutablePointer<UInt8>,
+        capacity: Int
+    ) -> AnyCancellable {
+        let subscriber = Subscribers.Stream(toBuffer: buffer, capacity: capacity)
+        subscribe(subscriber)
+        return AnyCancellable(subscriber)
+    }
+
+    func stream(toURL url: URL, append: Bool) -> AnyCancellable {
+        let subscriber = Subscribers.Stream(toURL: url, append: append)
+        subscribe(subscriber)
+        return AnyCancellable(subscriber)
+    }
+}
+
+public extension Subscribers {
+    final class Stream: Subscriber, Cancellable, CustomStringConvertible {
+        public typealias Input = [UInt8]
+        public typealias Failure = Error
+        
+        private var state: StreamState
+        private let lock = Lock()
+        
+        public init(toBuffer buffer: UnsafeMutablePointer<UInt8>, capacity: Int) {
+            let stream = OutputStream(toBuffer: buffer, capacity: capacity)
+            state = .awaitingSubscription(stream)
+        }
+        
+        public init(toURL url: URL, append: Bool) {
+            if let stream = OutputStream(url: url, append: append) {
+                state = .awaitingSubscription(stream)
+            } else {
+                state = .error(StreamError.couldNotLoadFileAtURL(url))
+            }
+        }
+        
+        deinit {
+            cancel()
+        }
+
+        public var description: String { "Stream" }
+        
+        public func cancel() {
+            if let subsription = lock.locked({ state.subscription }) {
+                subsription.cancel()
+            }
+            receive(completion: .finished)
+        }
+        
+        public func receive(subscription: Subscription) {
+            let validSub: Subscription? = lock.locked {
+                switch state {
+                case let .awaitingSubscription(stream):
+                    stream.open()
+                    guard stream.hasSpaceAvailable else {
+                        if let error = stream.streamError {
+                            state = .error(error)
+                            subscription.cancel()
+                            return nil
+                        } else {
+                            state = .finished
+                            subscription.cancel()
+                            return nil
+                        }
+                    }
+                    state = .streaming(stream, subscription)
+                    return subscription
+
+                case .streaming, .error, .finished:
+                    subscription.cancel()
+                    return nil
+                }
+            }
+            
+            validSub?.request(newDemand)
+        }
+        
+        public func receive(_ input: [UInt8]) -> Subscribers.Demand {
+            guard let stream = lock.locked({ state.openStream })
+            else { return .none }
+            
+            let result = stream.write(input, maxLength: input.count)
+            
+            switch result {
+            case 0:
+                stream.close()
+                lock.locked { state = .finished }
+                return .none
+                
+            case -1:
+                stream.close()
+                lock.locked { state = .error(stream.streamError ?? StreamError.unknown) }
+                return .none
+                
+            default:
+                return stream.hasSpaceAvailable ? .max(1) : .none
+            }
+        }
+        
+        public func receive(completion: Subscribers.Completion<Error>) {
+            lock.locked {
+                switch state {
+                case let .awaitingSubscription(stream):
+                    // We never opened it, but calling `close()` on an unopened
+                    // stream doesn't appear to cause any problems. So, we do
+                    // it just to be safe.
+                    stream.close()
+                    state = StreamState(completion)
+                    
+                case let .streaming(stream, _):
+                    stream.close()
+                    state = StreamState(completion)
+                    
+                case .finished, .error:
+                    break
+                }
+            }
+        }
+
+        private var newDemand: Subscribers.Demand {
+            guard let stream = lock.locked({ state.openStream })
+            else { return .none }
+
+            return stream.hasSpaceAvailable ? .max(1) : .none
+        }
+    }
+}
+
+
+private enum StreamState {
+    case awaitingSubscription(OutputStream)
+    case streaming(OutputStream, Subscription)
+    case error(Error)
+    case finished
+
+    init(_ completion: Subscribers.Completion<Error>) {
+        switch completion {
+        case .finished:
+            self = .finished
+        case let .failure(error):
+            self = .error(error)
+        }
+    }
+
+    var subscription: Subscription? {
+        switch self {
+        case let .streaming(_, subscription):
+            return subscription
+        case .awaitingSubscription, .error, .finished:
+            return nil
+        }
+    }
+
+    var openStream: OutputStream? {
+        switch self {
+        case .awaitingSubscription, .error, .finished:
+            return nil
+        case let .streaming(stream, _):
+            return stream
+        }
+    }
+}
+
+private enum StreamType {
+    case buffer(UnsafeMutablePointer<UInt8>)
+    case url(URL)
+}
+
+private enum StreamError: Error {
+    case unknown
+    case couldNotLoadFileAtURL(URL)
+}

--- a/Tests/CombineExtensionsTests/StreamSubscriberTests.swift
+++ b/Tests/CombineExtensionsTests/StreamSubscriberTests.swift
@@ -1,0 +1,324 @@
+import Combine
+import CombineExtensions
+import CombineTestExtensions
+import XCTest
+
+class StreamSubscriberTests: XCTestCase {
+    private var buffer: UnsafeMutablePointer<UInt8>!
+    private let bufferCapacity: Int = 10
+
+    private var bytes: [UInt8] {
+        (0..<bufferCapacity).map { buffer[$0] }
+    }
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        buffer = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferCapacity)
+        buffer.initialize(repeating: 0, count: bufferCapacity)
+    }
+
+    override func tearDownWithError() throws {
+        try super.tearDownWithError()
+        buffer.deinitialize(count: bufferCapacity)
+        buffer.deallocate()
+    }
+
+    func testStreamSubscriberWithData() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+        let input: [UInt8] = [72, 101, 108, 108, 111, 33] // Hello!
+
+        let subscriptionEx = expectation(description: "Should have received subscription")
+        let outputEx = expectation(description: "Should have received 6 bytes")
+        outputEx.expectedFulfillmentCount = 6
+        let completionEx = expectation(description: "Should have received completion")
+        let demandEx = expectation(description: "Should have received 7 demands")
+        demandEx.expectedFulfillmentCount = 7
+
+        var outputIndex = 0
+        let sub = subject
+            .handleEvents(
+                receiveSubscription: { _ in subscriptionEx.fulfill() },
+                receiveOutput: { (bytes) in
+                    XCTAssertEqual(1, bytes.count)
+                    XCTAssertEqual(input[outputIndex], bytes[0])
+                    outputIndex += 1
+                    outputEx.fulfill()
+                },
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        completionEx.fulfill()
+                    case let .failure(error):
+                        XCTFail("Should not have received error: \(error.localizedDescription)")
+                    }
+                },
+                receiveRequest: { demand in
+                    XCTAssertEqual(.max(1), demand)
+                    demandEx.fulfill()
+                }
+            )
+            .stream(toBuffer: buffer, capacity: bufferCapacity)
+
+        defer { sub.cancel() }
+
+        wait(for: [subscriptionEx], timeout: 2)
+
+        input.forEach { subject.send([$0]) }
+        subject.send(completion: .finished)
+
+        wait(for: [outputEx, completionEx, demandEx], timeout: 2)
+
+        XCTAssertEqual(
+            [72, 101, 108, 108, 111, 33, 0, 0, 0, 0] as [UInt8],
+            bytes
+        )
+    }
+
+    func testStreamSubscriberWithTooMuchData() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+        let input: [UInt8] = [
+            72, 101, 108, 108, 111, 33, // Hello!
+            72, 101, 108, 108, 111, 33, // Hello!
+        ]
+
+        let subscriptionEx = expectation(description: "Should have received subscription")
+        let outputEx = expectation(description: "Should have received 10 bytes")
+        outputEx.expectedFulfillmentCount = bufferCapacity
+        let completionEx = expectation(description: "Should not have received completion")
+        completionEx.isInverted = true
+        var cancelEx: XCTestExpectation? = expectation(description: "Should have received cancel")
+        cancelEx?.isInverted = true
+        let demandEx = expectation(description: "Should have received 10 demands")
+        demandEx.expectedFulfillmentCount = bufferCapacity
+
+        var outputIndex = 0
+        let sub = subject
+            .handleEvents(
+                receiveSubscription: { _ in subscriptionEx.fulfill() },
+                receiveOutput: { (bytes) in
+                    XCTAssertEqual(1, bytes.count)
+                    XCTAssertEqual(input[outputIndex], bytes[0])
+                    outputIndex += 1
+                    outputEx.fulfill()
+                },
+                receiveCompletion: { _ in completionEx.fulfill() },
+                receiveCancel: { cancelEx?.fulfill() },
+                receiveRequest: { demand in
+                    let expected = outputIndex <= self.bufferCapacity ?
+                        Subscribers.Demand.max(1) :
+                        .none
+                    XCTAssertEqual(expected, demand)
+                    demandEx.fulfill()
+                }
+            )
+            .stream(toBuffer: buffer, capacity: bufferCapacity)
+
+        defer { sub.cancel() }
+
+        wait(for: [subscriptionEx], timeout: 2)
+
+        input.forEach { subject.send([$0]) }
+
+        wait(for: [outputEx, demandEx], timeout: 2)
+
+        wait(for: [completionEx, cancelEx!], timeout: 0.1)
+        cancelEx = nil // `defer { sub.cancel() }` might trigger this inverted exception
+
+        XCTAssertEqual(
+            [72, 101, 108, 108, 111, 33, 72, 101, 108, 108,] as [UInt8],
+            bytes
+        )
+    }
+
+    func testStreamSubscriberDataSentBeforeSubscribingToBufferedSubject() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+        let input: [UInt8] = [72, 101, 108, 108, 111, 33] // Hello!
+
+        let outputEx = expectation(description: "Should have received 6 bytes")
+        outputEx.expectedFulfillmentCount = 6
+        let completionEx = expectation(description: "Should have received completion")
+        let demandEx = expectation(description: "Should have received 7 demands")
+        demandEx.expectedFulfillmentCount = 7
+
+        var outputIndex = 0
+        let sub = subject
+            .buffer(size: bufferCapacity, prefetch: .byRequest, whenFull: .dropOldest)
+            .handleEvents(
+                receiveSubscription: { _ in
+                    input.forEach { subject.send([$0]) }
+                    subject.send(completion: .finished)
+                },
+                receiveOutput: { (bytes) in
+                    XCTAssertEqual(1, bytes.count)
+                    XCTAssertEqual(input[outputIndex], bytes[0])
+                    outputIndex += 1
+                    outputEx.fulfill()
+                },
+                receiveCompletion: { completion in
+                    switch completion {
+                    case .finished:
+                        completionEx.fulfill()
+                    case let .failure(error):
+                        XCTFail("Should not have received error: \(error.localizedDescription)")
+                    }
+                },
+                receiveRequest: { demand in
+                    XCTAssertEqual(.max(1), demand)
+                    demandEx.fulfill()
+                }
+            )
+            .stream(toBuffer: buffer, capacity: bufferCapacity)
+
+        defer { sub.cancel() }
+
+        wait(for: [outputEx, completionEx, demandEx], timeout: 2)
+
+        XCTAssertEqual(
+            [72, 101, 108, 108, 111, 33, 0, 0, 0, 0] as [UInt8],
+            bytes
+        )
+    }
+
+    func testStreamSubscriberSucceedsWithValidURL() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+        let input: [UInt8] = [72, 101, 108, 108, 111, 33] // Hello!
+
+        let tempDir = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("testStreamSubscriberSucceedsWithValidURL-\(arc4random())")
+
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+        let url = tempDir.appendingPathComponent("text.txt")
+
+        defer {
+            try? FileManager.default.removeItem(at: tempDir)
+        }
+
+        let subscriptionEx = expectation(description: "Should have received subscription")
+        let outputEx = expectation(description: "Should have received 6 bytes")
+        outputEx.expectedFulfillmentCount = 6
+
+        let sub = subject
+            .handleEvents(
+                receiveSubscription: { _ in subscriptionEx.fulfill() },
+                receiveOutput: { _ in outputEx.fulfill() }
+            )
+            .stream(toURL: url, append: false)
+
+        defer { sub.cancel() }
+
+        wait(for: [subscriptionEx], timeout: 2)
+
+        input.forEach { subject.send([$0]) }
+        subject.send(completion: .finished)
+
+        wait(for: [outputEx], timeout: 2)
+
+        XCTAssertEqual("Hello!", try String(contentsOf: url))
+    }
+
+    func testStreamSubscriberFailsForInvalidURL() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+
+        let url = FileManager.default
+            .temporaryDirectory
+            .appendingPathComponent("this-folder-does-not-exist")
+            .appendingPathComponent("this-file-does-not-exist-\(arc4random()).dat")
+
+        let subscriptionEx = expectation(description: "Should have received subscription")
+        let outputEx = expectation(description: "Should have received 10 bytes")
+        outputEx.isInverted = true
+        let failureEx = expectation(description: "Should not have received failure")
+        failureEx.isInverted = true
+        var cancelEx: XCTestExpectation? = expectation(description: "Should not have received cancel")
+        let demandEx = expectation(description: "Should not have received demand")
+        demandEx.isInverted = true
+
+        let sub = subject
+            .handleEvents(
+                receiveSubscription: { _ in subscriptionEx.fulfill() },
+                receiveOutput: { _ in outputEx.fulfill() },
+                receiveCompletion: { _ in failureEx.fulfill() },
+                receiveCancel: { cancelEx?.fulfill() },
+                receiveRequest: { _ in demandEx.fulfill() }
+            )
+            .stream(toURL: url, append: false)
+
+        defer { sub.cancel() }
+
+        wait(for: [subscriptionEx, cancelEx!], timeout: 2)
+
+        subject.send([72])
+
+        wait(for: [outputEx, failureEx, demandEx], timeout: 0.1)
+        cancelEx = nil
+    }
+
+    func testUnretainedStreamSubscriberNeverReceivesOutputOrCompletion() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+
+        let subscriptionEx = expectation(description: "Should have received subscription")
+        let outputEx = expectation(description: "Should not have received output")
+        outputEx.isInverted = true
+        let completionEx = expectation(description: "Should not have received completion")
+        completionEx.isInverted = true
+        let demandEx = expectation(description: "Should have received demand")
+
+        let _ = subject
+            .handleEvents(
+                receiveSubscription: { _ in subscriptionEx.fulfill() },
+                receiveOutput: { _ in outputEx.fulfill() },
+                receiveCompletion: { _ in completionEx.fulfill() },
+                receiveRequest: { demand in
+                    XCTAssertEqual(.max(1), demand)
+                    demandEx.fulfill()
+                }
+            )
+            .stream(toBuffer: buffer, capacity: bufferCapacity)
+
+        wait(for: [subscriptionEx, demandEx], timeout: 2)
+
+        subject.send([42])
+        subject.send(completion: .finished)
+
+        wait(for: [outputEx, completionEx], timeout: 0.1)
+
+        XCTAssertEqual([0, 0, 0, 0, 0, 0, 0, 0, 0, 0] as [UInt8], bytes)
+    }
+
+    func testCancelledStreamSubscriberNeverReceivesOutputOrCompletion() throws {
+        let subject = PassthroughSubject<[UInt8], Error>()
+
+        let completionEx = expectation(description: "Should not have received completion")
+        completionEx.isInverted = true
+        let cancelEx = expectation(description: "Should have received cancel")
+        let demandEx = expectation(description: "Should have received demand")
+        demandEx.assertForOverFulfill = false
+
+        let sub = subject
+            .handleEvents(
+                receiveCompletion: { _ in completionEx.fulfill() },
+                receiveCancel: { cancelEx.fulfill() },
+                receiveRequest: { demand in
+                    XCTAssertEqual(.max(1), demand)
+                    demandEx.fulfill()
+                }
+            )
+            .stream(toBuffer: buffer, capacity: bufferCapacity)
+
+        wait(for: [demandEx], timeout: 2)
+
+        subject.send([42])
+
+        sub.cancel()
+
+        subject.send([127])
+        subject.send(completion: .finished)
+
+        wait(for: [cancelEx], timeout: 2)
+        wait(for: [completionEx], timeout: 0.1)
+
+        XCTAssertEqual([42, 0, 0, 0, 0, 0, 0, 0, 0, 0] as [UInt8], bytes)
+    }
+}


### PR DESCRIPTION
- [x] Add `Subscribers.Stream` to handle subscribing to a publisher of bytes
- [x] Fix the way our custom subscriptions handle cancellation