### PR TITLE
Add SingleSubscriptionStore and tests

### DIFF
--- a/Sources/CombineExtensions/SingleSubscriptionStore.swift
+++ b/Sources/CombineExtensions/SingleSubscriptionStore.swift
@@ -1,0 +1,38 @@
+import Combine
+import Synchronized
+
+public extension Cancellable {
+    func store(in store: SingleSubscriptionStore) {
+        store.store(subscription: AnyCancellable(self))
+    }
+}
+
+public class SingleSubscriptionStore: Hashable {
+    private var subscription: AnyCancellable?
+    private let lock = Lock()
+
+    public init(_ subscription: AnyCancellable? = nil) {
+        self.subscription = subscription
+    }
+
+    public func store(subscription: AnyCancellable) {
+        lock.locked { self.subscription = subscription }
+    }
+
+    @discardableResult
+    public func removeSubscription() -> AnyCancellable? {
+        lock.locked {
+            let sub = subscription
+            subscription = nil
+            return sub
+        }
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(self))
+    }
+
+    public static func == (lhs: SingleSubscriptionStore, rhs: SingleSubscriptionStore) -> Bool {
+        ObjectIdentifier(lhs) == ObjectIdentifier(rhs)
+    }
+}

--- a/Tests/CombineExtensionsTests/SingleSubscriptionStoreTests.swift
+++ b/Tests/CombineExtensionsTests/SingleSubscriptionStoreTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Combine
+import CombineExtensions
+import CombineTestExtensions
+
+class SingleSubscriptionStoreTests: XCTestCase {
+    func testSingleSubscriptionStoreEquatableAndHashable() throws {
+        let one = SingleSubscriptionStore()
+        let two = SingleSubscriptionStore()
+
+        let sameAsOne = one
+
+        XCTAssertEqual(one, one)
+        XCTAssertEqual(one, sameAsOne)
+        XCTAssertEqual(one.hashValue, one.hashValue)
+        XCTAssertEqual(one.hashValue, sameAsOne.hashValue)
+
+        XCTAssertNotEqual(one, two)
+        XCTAssertNotEqual(one.hashValue, two.hashValue)
+
+        [1, 2, 3]
+            .publisher
+            .sink { _ in }
+            .store(in: sameAsOne)
+
+        XCTAssertEqual(one, sameAsOne)
+        XCTAssertEqual(one.hashValue, sameAsOne.hashValue)
+    }
+
+    func testStoringSubscriptionPreventsCancellation() throws {
+        let store = SingleSubscriptionStore()
+
+        let subject = PassthroughSubject<Int, Never>()
+
+        let receiveEx = expectation(description: "Should have received '1'")
+        receiveEx.assertForOverFulfill = true
+
+        let doNotReceiveEx = expectation(description: "Should not have received '2'")
+        doNotReceiveEx.isInverted = true
+
+        subject.sink { value in
+            if value == 1 {
+                receiveEx.fulfill()
+            } else if value == 2 {
+                doNotReceiveEx.fulfill()
+            } else {
+                XCTFail()
+            }
+        }
+        .store(in: store)
+
+        subject.send(1)
+        wait(for: [receiveEx], timeout: 2)
+
+        store.removeSubscription()
+        subject.send(2)
+        wait(for: [doNotReceiveEx], timeout: 0.1)
+    }
+}


### PR DESCRIPTION
`SingleSubscriptionStore` is intended to be used inside of immutable value types that hold on to Combine pipelines.