### PR TITLE
Add MeasuredSink and KeyedSubscriptionStore

### DIFF
--- a/Sources/CombineExtensions/MeasuredSink.swift
+++ b/Sources/CombineExtensions/MeasuredSink.swift
@@ -1,0 +1,144 @@
+import Foundation
+import Combine
+import Synchronized
+
+extension Publisher {
+    public func measuredSink(
+        initialDemand: Subscribers.Demand = .none,
+        receiveValue: @escaping (Output) -> Subscribers.Demand,
+        receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void
+    ) -> DemandCancellable<Output, Failure> {
+        let sink = MeasuredSink<Output, Failure>(
+            initialDemand: initialDemand,
+            receiveValue: receiveValue,
+            receiveCompletion: receiveCompletion
+        )
+        subscribe(sink)
+        return DemandCancellable(sink)
+    }
+}
+
+extension Publisher where Failure == Never {
+    public func measuredSink(
+        initialDemand: Subscribers.Demand = .none,
+        receiveValue: @escaping (Output) -> Subscribers.Demand
+    ) -> DemandCancellable<Output, Failure> {
+        let sink = MeasuredSink<Output, Failure>(
+            initialDemand: initialDemand,
+            receiveValue: receiveValue,
+            receiveCompletion: { _ in }
+        )
+        subscribe(sink)
+        return DemandCancellable(sink)
+    }
+}
+
+public final class DemandCancellable<Input, Failure>: Cancellable where Failure: Error {
+    private let sink: MeasuredSink<Input, Failure>
+
+    init(_ sink: MeasuredSink<Input, Failure>) {
+        self.sink = sink
+    }
+
+    public func request(demand: Subscribers.Demand) {
+        sink.request(demand: demand)
+    }
+
+    public func cancel() {
+        sink.cancel()
+    }
+}
+
+/// A simple subscriber that requests a custom number of values upon subscription
+/// and after receiving new values.
+final class MeasuredSink<Input, Failure>: Subscriber, Cancellable where Failure: Error {
+    private enum State {
+        case unsubscribed(Subscribers.Demand)
+        case subscribed(Subscription)
+        case finished
+    }
+
+    private let onReceiveValue: (Input) -> Subscribers.Demand
+    private let onReceiveCompletion: (Subscribers.Completion<Failure>) -> Void
+
+    private var state: State
+    private let lock = RecursiveLock()
+
+    init(
+        initialDemand: Subscribers.Demand,
+        receiveValue: @escaping (Input) -> Subscribers.Demand,
+        receiveCompletion: @escaping (Subscribers.Completion<Failure>) -> Void
+    ) {
+        state = .unsubscribed(initialDemand)
+        onReceiveValue = receiveValue
+        onReceiveCompletion = receiveCompletion
+    }
+
+    func request(demand: Subscribers.Demand) {
+        guard demand > .none else { return }
+
+        lock.locked {
+            switch state {
+            case let .unsubscribed(previousDemand):
+                state = .unsubscribed(previousDemand + demand)
+
+            case let .subscribed(subscription):
+                subscription.request(demand)
+
+            case .finished:
+                break
+            }
+        }
+    }
+
+    func receive(subscription: Subscription) {
+        let (didSet, demand): (Bool, Subscribers.Demand) = lock.locked {
+            guard case let .unsubscribed(demand) = state else {
+                return (false, .none)
+            }
+            state = .subscribed(subscription)
+            return (true, demand)
+        }
+
+        if didSet {
+            request(demand: demand)
+        } else {
+            subscription.cancel()
+        }
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+        let shouldReceive: Bool = lock.locked {
+            switch state {
+            case .unsubscribed, .subscribed:
+                return true
+            case .finished:
+                return false
+            }
+        }
+
+        guard shouldReceive else { return .none }
+        return onReceiveValue(input)
+    }
+
+    func receive(completion: Subscribers.Completion<Failure>) {
+        onReceiveCompletion(completion)
+        lock.locked { state = .finished }
+    }
+
+    func cancel() {
+        let sub: Subscription? = lock.locked {
+            switch state {
+            case let .subscribed(subscription):
+                state = .finished
+                return subscription
+
+            case .unsubscribed, .finished:
+                state = .finished
+                return nil
+            }
+        }
+
+        sub?.cancel()
+    }
+}

--- a/Sources/CombineExtensions/SingleSubscriptionStore.swift
+++ b/Sources/CombineExtensions/SingleSubscriptionStore.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Combine
 import Synchronized
 
@@ -8,24 +9,22 @@ public extension Cancellable {
 }
 
 public class SingleSubscriptionStore: Hashable {
-    private var subscription: AnyCancellable?
-    private let lock = Lock()
+    private let key = UUID().uuidString
+    private let keyedSubscriptionStore = KeyedSubscriptionStore()
 
     public init(_ subscription: AnyCancellable? = nil) {
-        self.subscription = subscription
+        if let sub = subscription {
+            keyedSubscriptionStore.store(subscription: sub, forKey: key)
+        }
     }
 
     public func store(subscription: AnyCancellable) {
-        lock.locked { self.subscription = subscription }
+        keyedSubscriptionStore.store(subscription: subscription, forKey: key)
     }
 
     @discardableResult
     public func removeSubscription() -> AnyCancellable? {
-        lock.locked {
-            let sub = subscription
-            subscription = nil
-            return sub
-        }
+        keyedSubscriptionStore.removeSubscription(forKey: key)
     }
 
     public func hash(into hasher: inout Hasher) {

--- a/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
+++ b/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import Combine
+import CombineExtensions
+import CombineTestExtensions
+
+class KeyedSubscriptionStoreTests: XCTestCase {
+    func testKeyedSubscriptionStoreEquatableAndHashable() throws {
+        let one = KeyedSubscriptionStore()
+        let two = KeyedSubscriptionStore()
+
+        let sameAsOne = one
+
+        XCTAssertEqual(one, one)
+        XCTAssertEqual(one, sameAsOne)
+        XCTAssertEqual(one.hashValue, one.hashValue)
+        XCTAssertEqual(one.hashValue, sameAsOne.hashValue)
+
+        XCTAssertNotEqual(one, two)
+        XCTAssertNotEqual(one.hashValue, two.hashValue)
+
+        [1, 2, 3]
+            .publisher
+            .sink { _ in }
+            .store(in: sameAsOne, key: "integers")
+
+        XCTAssertEqual(one, sameAsOne)
+        XCTAssertEqual(one.hashValue, sameAsOne.hashValue)
+    }
+
+    func testStoringSubscriptionPreventsCancellation() throws {
+        let store = KeyedSubscriptionStore()
+
+        let subject1 = PassthroughSubject<Int, Never>()
+        let subject2 = PassthroughSubject<Int, Never>()
+
+        let subject1Ex = expectation(description: "Should have received '1' and '3'")
+        subject1Ex.expectedFulfillmentCount = 2
+        let subject2Ex = expectation(description: "Should have received '2'")
+        let doNotReceiveEx = expectation(description: "Should not have received '4'")
+        doNotReceiveEx.isInverted = true
+
+        subject1.sink { value in
+            if value == 1 || value == 3 { subject1Ex.fulfill() }
+            else { XCTFail() }
+        }
+        .store(in: store, key: "subject1")
+
+        subject2.sink { value in
+            if value == 2 { subject2Ex.fulfill() }
+            else { doNotReceiveEx.fulfill() }
+        }
+        .store(in: store, key: "subject2")
+
+        subject1.send(1)
+        subject2.send(2)
+        store.removeSubscription(forKey: "subject2")
+        subject1.send(3)
+        subject2.send(4)
+
+        wait(for: [subject1Ex, subject2Ex], timeout: 2)
+        wait(for: [doNotReceiveEx], timeout: 0.1)
+    }
+}
+

--- a/Tests/CombineExtensionsTests/MeasuredSinkTests.swift
+++ b/Tests/CombineExtensionsTests/MeasuredSinkTests.swift
@@ -1,0 +1,92 @@
+import XCTest
+import Combine
+import CombineExtensions
+
+final class MeasuredSinkTests: XCTestCase {
+    func testDoesNotPublishWithoutDemand() throws {
+        let ex = expectation(description: "Should not have received value")
+        ex.isInverted = true
+
+        let pub = [1, 2, 3].publisher
+        let sub = pub.measuredSink { _ in
+            ex.fulfill()
+            return .none
+        }
+        defer { sub.cancel() }
+
+        wait(for: [ex], timeout: 0.1)
+    }
+
+    func testPublishesInitialDemand() throws {
+        let ex = expectation(description: "Should have received one value")
+
+        let pub = [1, 2, 3].publisher
+        let sub = pub.measuredSink(initialDemand: .max(1)) { value in
+            XCTAssertEqual(1, value)
+            ex.fulfill()
+            return .none
+        }
+        defer { sub.cancel() }
+
+        wait(for: [ex], timeout: 2)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+    }
+
+    func testPublishesAfterRequestDemand() throws {
+        let ex = expectation(description: "Should have received value")
+        ex.expectedFulfillmentCount = 2
+
+        let pub = [1, 2, 3].publisher
+        let sub = pub.measuredSink { _ in
+            ex.fulfill()
+            return .none
+        }
+        defer { sub.cancel() }
+
+        sub.request(demand: .max(2))
+        wait(for: [ex], timeout: 2)
+    }
+
+    func testDoesNotPublishAfterCancelling() throws {
+        let ex = expectation(description: "Should have received value")
+
+        let pub = [1, 2, 3].publisher
+        let sub = pub.measuredSink { _ in
+            ex.fulfill()
+            return .none
+        }
+
+        sub.request(demand: .max(1))
+        wait(for: [ex], timeout: 2)
+
+        sub.cancel()
+        sub.request(demand: .max(1))
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+    }
+
+    func testDoesNotOverflowStack() throws {
+        let count = 1_000
+
+        let ex = expectation(description: "Should have received value")
+        ex.expectedFulfillmentCount = count
+
+        struct Iter: IteratorProtocol {
+            private var int = 0
+            mutating func next() -> Int? {
+                int += 1
+                return int
+            }
+        }
+
+        let sub = AnySequence(Iter.init)
+            .publisher
+            .measuredSink { (value: Int) -> Subscribers.Demand in
+                ex.fulfill()
+                return .none
+            }
+        defer { sub.cancel() }
+
+        sub.request(demand: .max(count))
+        wait(for: [ex], timeout: 10 * 60)
+    }
+}


### PR DESCRIPTION
- [x] Add `KeyedSubscriptionStore` to allow storing multiple, named Combine publisher pipelines
- [x] Add `MeasuredSink` to allow easy customizability of demand in Combine publisher pipelines