### PR TITLE
Publish values only when new values have been emitted

### DIFF
--- a/Sources/CombineExtensions/InputStreamPublisher.swift
+++ b/Sources/CombineExtensions/InputStreamPublisher.swift
@@ -105,7 +105,12 @@ private final class InputStreamSubscription<S: Subscriber>: Subscription
 
     func request(_ demand: Subscribers.Demand) {
         guard demand != .none else { return }
-        lock.locked { self.demand += demand }
+        let shouldPublish: Bool = lock.locked {
+            let shouldPublish = self.demand == .none
+            self.demand += demand
+            return shouldPublish
+        }
+        guard shouldPublish else { return }
         publish()
     }
 

--- a/Sources/CombineExtensions/ReduceLatest.swift
+++ b/Sources/CombineExtensions/ReduceLatest.swift
@@ -194,7 +194,12 @@ private final class ReduceLatestSubscription<Subscriber, A, B, C, D, Output, Fai
 
     func request(_ demand: Subscribers.Demand) {
         guard demand != .none else { return }
-        lock.locked { self.demand += demand }
+        let shouldPublish: Bool = lock.locked {
+            let shouldPublish = self.demand == .none
+            self.demand += demand
+            return shouldPublish
+        }
+        guard shouldPublish else { return }
         publish()
     }
 

--- a/Sources/CombineExtensions/RetryIf.swift
+++ b/Sources/CombineExtensions/RetryIf.swift
@@ -3,6 +3,21 @@ import Combine
 import Synchronized
 
 extension Publisher {
+    public func retry<Context: Scheduler>(
+        after interval: @escaping (Int) -> Context.SchedulerTimeType.Stride,
+        tolerance: Context.SchedulerTimeType.Stride? = nil,
+        scheduler: Context,
+        options: Context.SchedulerOptions? = nil
+    ) -> Publishers.RetryIf<Self, Context> {
+        retryIf(
+            { _ in true },
+            after: interval,
+            tolerance: tolerance,
+            scheduler: scheduler,
+            options: options
+        )
+    }
+
     public func retryIf<Context: Scheduler>(
         _ predicate: @escaping (Failure) -> Bool,
         after interval: Context.SchedulerTimeType.Stride,


### PR DESCRIPTION
- [x] Fix a bug in which subscribers who always request some demand after receiving a value would cause `ReduceLatest` to republish values constantly
- [x] Add `Publisher.retry(after:tolerance:scheduler:options:)` powered by `RetryIf` that retries for any error with a dynamic retry delay