### PR TITLE
Add KeyedSubscriptionStore.removeAll()

### DIFF
--- a/Sources/CombineExtensions/KeyedSubscriptionStore.swift
+++ b/Sources/CombineExtensions/KeyedSubscriptionStore.swift
@@ -7,7 +7,7 @@ public extension Cancellable {
     }
 }
 
-public class KeyedSubscriptionStore: Hashable {
+public final class KeyedSubscriptionStore: Hashable {
     private var subscriptions: [String: AnyCancellable]
     private let lock = Lock()
 
@@ -17,6 +17,10 @@ public class KeyedSubscriptionStore: Hashable {
 
     public func store(subscription: AnyCancellable, forKey key: String) {
         lock.locked { self.subscriptions[key] = subscription }
+    }
+
+    public func removeAll(keepingCapacity keepCapacity: Bool = false) {
+        lock.locked { subscriptions.removeAll(keepingCapacity: keepCapacity) }
     }
 
     @discardableResult

--- a/Sources/CombineExtensions/SingleSubscriptionStore.swift
+++ b/Sources/CombineExtensions/SingleSubscriptionStore.swift
@@ -8,7 +8,7 @@ public extension Cancellable {
     }
 }
 
-public class SingleSubscriptionStore: Hashable {
+public final class SingleSubscriptionStore: Hashable {
     private let key = UUID().uuidString
     private let keyedSubscriptionStore = KeyedSubscriptionStore()
 

--- a/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
+++ b/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
@@ -60,5 +60,32 @@ class KeyedSubscriptionStoreTests: XCTestCase {
         wait(for: [subject1Ex, subject2Ex], timeout: 2)
         wait(for: [doNotReceiveEx], timeout: 0.1)
     }
+
+    func testRemoveAll() throws {
+        let store = KeyedSubscriptionStore()
+
+        let subject1 = PassthroughSubject<Int, Never>()
+        let subject2 = PassthroughSubject<Int, Never>()
+
+        var receivedFrom1 = [Int]()
+        var receivedFrom2 = [Int]()
+
+        subject1
+            .sink(receiveValue: { receivedFrom1.append($0) })
+            .store(in: store, key: "one")
+
+        subject2
+            .sink(receiveValue: { receivedFrom2.append($0) })
+            .store(in: store, key: "two")
+
+        subject1.send(1)
+        subject2.send(2)
+        store.removeAll()
+        subject1.send(11)
+        subject2.send(12)
+
+        XCTAssertEqual([1], receivedFrom1)
+        XCTAssertEqual([2], receivedFrom2)
+    }
 }
 


### PR DESCRIPTION
This pull requests adds `KeyedSubscriptionStore.removeAll()` to make it easy to remove all subscriptions from a store at once.