### PR TITLE
Add AnyConnectablePublisher and tests

### DIFF
--- a/Sources/CombineExtensions/AnyConnectablePublisher.swift
+++ b/Sources/CombineExtensions/AnyConnectablePublisher.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Combine
+
+extension ConnectablePublisher {
+    public func eraseToAnyConnectablePublisher() -> AnyConnectablePublisher<Output, Failure> {
+        AnyConnectablePublisher(self)
+    }
+}
+
+public struct AnyConnectablePublisher<Output, Failure: Error>: ConnectablePublisher {
+    private let publisher: _Box<Output, Failure>
+
+    fileprivate init<P: ConnectablePublisher>(
+        _ publisher: P
+    ) where P.Output == Output, P.Failure == Failure {
+        self.publisher = Box(publisher)
+    }
+
+    public func receive<S: Subscriber>(
+        subscriber: S
+    ) where S.Failure == Failure, S.Input == Output {
+        publisher.receive(subscriber: subscriber)
+    }
+
+    public func connect() -> Cancellable {
+        publisher.connect()
+    }
+}
+
+private class _Box<Output, Failure: Error>: ConnectablePublisher {
+    init() {}
+
+    func receive<S: Subscriber>(
+        subscriber: S
+    ) where S.Failure == Failure, S.Input == Output {
+        preconditionFailure()
+    }
+
+    func connect() -> Cancellable {
+        preconditionFailure()
+    }
+}
+
+private final class Box<Wrapped: ConnectablePublisher>: _Box<Wrapped.Output, Wrapped.Failure> {
+    fileprivate let wrapped: Wrapped
+
+    fileprivate init(_ publisher: Wrapped) {
+        wrapped = publisher
+    }
+
+    fileprivate override func receive<S: Subscriber>(
+        subscriber: S
+    ) where S.Failure == Failure, S.Input == Output {
+        wrapped.receive(subscriber: subscriber)
+    }
+
+    fileprivate override func connect() -> Cancellable {
+        wrapped.connect()
+    }
+}

--- a/Tests/CombineExtensionsTests/AnyConnectablePublisherTests.swift
+++ b/Tests/CombineExtensionsTests/AnyConnectablePublisherTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+import Combine
+import CombineExtensions
+import CombineTestExtensions
+
+final class AnyConnectablePublisherTests: XCTestCase {
+    func testErasedTimerCanStillBeConnectedTo() throws {
+        let pub = Timer.publish(every: 0.01, on: .main, in: .common).eraseToAnyConnectablePublisher()
+
+        var dates = [Date]()
+        var subscriptions = Set<AnyCancellable>()
+        pub.sink { date in
+            dates.append(date)
+            subscriptions.removeAll()
+        }
+        .store(in: &subscriptions)
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        XCTAssertTrue(dates.isEmpty)
+
+        pub.connect().store(in: &subscriptions)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        XCTAssertEqual(1, dates.count)
+        XCTAssertTrue(subscriptions.isEmpty)
+    }
+
+    func testAutoconnectAnyConnectablePublisher() throws {
+        var dates = [Date]()
+        var subscriptions = Set<AnyCancellable>()
+
+        Timer
+            .publish(every: 0.01, on: .main, in: .common)
+            .eraseToAnyConnectablePublisher()
+            .autoconnect()
+            .sink { date in
+                dates.append(date)
+                subscriptions.removeAll()
+            }
+            .store(in: &subscriptions)
+
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.1))
+        XCTAssertEqual(1, dates.count)
+        XCTAssertTrue(subscriptions.isEmpty)
+    }
+}


### PR DESCRIPTION
`AnyConnectablePublisher` allows `ConnectablePublisher`s to be wrapped in the same way instances of `Publisher` can be wrapped in `AnyPublisher`. This gives API designers the ability to hide implementation details behind a type-erased facade while not giving up the power of `ConnectablePublisher`.