### PR TITLE
Add isEmpty and containsSubscription(forKey:) to KeyedSubscriptionStore

### DIFF
--- a/Sources/CombineExtensions/KeyedSubscriptionStore.swift
+++ b/Sources/CombineExtensions/KeyedSubscriptionStore.swift
@@ -15,8 +15,14 @@ public final class KeyedSubscriptionStore: Hashable {
         self.subscriptions = subscriptions
     }
 
+    public var isEmpty: Bool { lock.locked { subscriptions.isEmpty } }
+
+    public func containsSubscription(forKey key: String) -> Bool {
+        lock.locked { subscriptions[key] != nil }
+    }
+
     public func store(subscription: AnyCancellable, forKey key: String) {
-        lock.locked { self.subscriptions[key] = subscription }
+        lock.locked { subscriptions[key] = subscription }
     }
 
     public func removeAll(keepingCapacity keepCapacity: Bool = false) {

--- a/Sources/CombineExtensions/SingleSubscriptionStore.swift
+++ b/Sources/CombineExtensions/SingleSubscriptionStore.swift
@@ -18,6 +18,8 @@ public final class SingleSubscriptionStore: Hashable {
         }
     }
 
+    public var isEmpty: Bool { keyedSubscriptionStore.isEmpty }
+
     public func store(subscription: AnyCancellable) {
         keyedSubscriptionStore.store(subscription: subscription, forKey: key)
     }

--- a/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
+++ b/Tests/CombineExtensionsTests/KeyedSubscriptionStoreTests.swift
@@ -4,6 +4,32 @@ import CombineExtensions
 import CombineTestExtensions
 
 class KeyedSubscriptionStoreTests: XCTestCase {
+    func testKeyedSubscriptionStoreIsEmptyAndContains() throws {
+        let store = KeyedSubscriptionStore()
+
+        XCTAssertTrue(store.isEmpty)
+
+        [1, 2, 3].publisher.sink { _ in }.store(in: store, key: "first")
+        [1, 2, 3].publisher.sink { _ in }.store(in: store, key: "second")
+
+        XCTAssertFalse(store.isEmpty)
+        XCTAssertTrue(store.containsSubscription(forKey: "first"))
+        XCTAssertTrue(store.containsSubscription(forKey: "second"))
+        XCTAssertFalse(store.containsSubscription(forKey: "third"))
+
+        store.removeSubscription(forKey: "second")
+        XCTAssertFalse(store.isEmpty)
+        XCTAssertTrue(store.containsSubscription(forKey: "first"))
+        XCTAssertFalse(store.containsSubscription(forKey: "second"))
+        XCTAssertFalse(store.containsSubscription(forKey: "third"))
+
+        store.removeSubscription(forKey: "first")
+        XCTAssertTrue(store.isEmpty)
+        XCTAssertFalse(store.containsSubscription(forKey: "first"))
+        XCTAssertFalse(store.containsSubscription(forKey: "second"))
+        XCTAssertFalse(store.containsSubscription(forKey: "third"))
+    }
+
     func testKeyedSubscriptionStoreEquatableAndHashable() throws {
         let one = KeyedSubscriptionStore()
         let two = KeyedSubscriptionStore()

--- a/Tests/CombineExtensionsTests/SingleSubscriptionStoreTests.swift
+++ b/Tests/CombineExtensionsTests/SingleSubscriptionStoreTests.swift
@@ -4,6 +4,19 @@ import CombineExtensions
 import CombineTestExtensions
 
 class SingleSubscriptionStoreTests: XCTestCase {
+    func testSingleSubscriptionStoreIsEmptyAndContains() throws {
+        let store = SingleSubscriptionStore()
+
+        XCTAssertTrue(store.isEmpty)
+
+        [1, 2, 3].publisher.sink { _ in }.store(in: store)
+
+        XCTAssertFalse(store.isEmpty)
+
+        store.removeSubscription()
+        XCTAssertTrue(store.isEmpty)
+    }
+
     func testSingleSubscriptionStoreEquatableAndHashable() throws {
         let one = SingleSubscriptionStore()
         let two = SingleSubscriptionStore()


### PR DESCRIPTION
Be aware that these methods are thread-safe to use _(in that they won't cause a crash if called from multiple threads at the same time)_ but, by the time the results have been returned, the subscriptions inside of the store may have changed and the returned value won't be valid anymore. Therefore, use them with caution.