### PR TITLE
Add Distinct publisher

### DIFF
--- a/Sources/CombineExtensions/Distinct.swift
+++ b/Sources/CombineExtensions/Distinct.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Combine
-import Synchronized
 
 extension Publisher {
     public func distinct<T: Hashable>() -> Publishers.Distinct<Self, T> where Output == Array<T> {

--- a/Sources/CombineExtensions/Distinct.swift
+++ b/Sources/CombineExtensions/Distinct.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Combine
+import Synchronized
+
+extension Publisher {
+    public func distinct<T: Hashable>() -> Publishers.Distinct<Self, T> where Output == Array<T> {
+        Publishers.Distinct(upstream: self)
+    }
+}
+
+extension Publishers {
+    public struct Distinct<Upstream: Publisher, T: Hashable>: Publisher where Upstream.Output == Array<T> {
+        public typealias Output = Upstream.Output
+        public typealias Failure = Upstream.Failure
+
+        private let upstream: Upstream
+
+        public init(upstream: Upstream) {
+            self.upstream = upstream
+        }
+
+        public func receive<S: Subscriber>(
+            subscriber: S
+        ) where Output == S.Input, Failure == S.Failure {
+            var previousValues = Set<T>()
+
+            self.upstream
+                .compactMap { (values: Upstream.Output) -> Upstream.Output? in
+                    var newValues: [T] = []
+                    for value in values {
+                        if !previousValues.contains(value) {
+                            previousValues.insert(value)
+                            newValues.append(value)
+                        }
+                    }
+                    return newValues.isEmpty ? nil : newValues
+                }
+                .receive(subscriber: subscriber)
+        }
+    }
+}
+
+

--- a/Tests/CombineExtensionsTests/DistinctTests.swift
+++ b/Tests/CombineExtensionsTests/DistinctTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import Combine
+import CombineExtensions
+import Synchronized
+
+final class DistinctTests: XCTestCase {
+    func testDistinctWithStringArraysPublisher() throws {
+        let pub = [
+            ["a", "b", "c"],
+            ["a", "b", "c", "d"],
+            ["b", "c", "d"],
+        ]
+            .publisher
+            .distinct()
+        
+        let expected = [
+            ["a", "b", "c"],
+            ["d"],
+        ]
+        
+        let ex = pub.expectOutput(expected)
+        
+        wait(for: [ex], timeout: 2)
+    }
+    
+    func testDistinctWithNumberArraysPublisher() throws {
+        let pub = [
+            [1, 2, 3],
+            [2, 3, 4, 5, 6],
+            [4, 5, 7],
+        ]
+            .publisher
+            .distinct()
+        
+        let expected = [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7],
+        ]
+        
+        let ex = pub.expectOutput(expected)
+        
+        wait(for: [ex], timeout: 2)
+    }
+    
+    func testDistinctWithStructArraysPublisher() throws {
+        struct WWDC: Hashable {
+            let year: Int
+        }
+        
+        let pub = [
+            [WWDC(year: 2016), WWDC(year: 2017), WWDC(year: 2015)],
+            [WWDC(year: 2015), WWDC(year: 2017), WWDC(year: 2018), WWDC(year: 2014)],
+            [WWDC(year: 2014), WWDC(year: 2020), WWDC(year: 2021)],
+        ]
+            .publisher
+            .distinct()
+        
+        let expected = [
+            [WWDC(year: 2016), WWDC(year: 2017), WWDC(year: 2015)],
+            [WWDC(year: 2018), WWDC(year: 2014)],
+            [WWDC(year: 2020), WWDC(year: 2021)],
+        ]
+        
+        let ex = pub.expectOutput(expected)
+        
+        wait(for: [ex], timeout: 2)
+    }
+    
+    func testDistinctWithDictArraysPublisher() throws {
+        let dicts: [[Dictionary<String, AnyHashable>]] = [
+            [["first": 1], ["second": "2"], ["third": 3.0]],
+            [["first": 1], ["third": 3.0], ["fourth": Int64(4)]],
+            [["first": 1], ["fifth": Double(5)]],
+        ]
+        
+        let pub = dicts
+            .publisher
+            .distinct()
+       
+        let expected: [[Dictionary<String, AnyHashable>]] = [
+            [["first": 1], ["second": "2"], ["third": 3.0]],
+            [["fourth": Int64(4)]],
+            [["fifth": Double(5)]],
+        ]
+        
+        let ex = pub.expectOutput(expected)
+        
+        wait(for: [ex], timeout: 2)
+    }
+    
+    func testDistinctConsecutivenessWithPassThroughSubject() throws {
+        let queue = DispatchQueue(label: "global.concurrent.queue", qos: .background, attributes: .concurrent)
+        
+        let subject = PassthroughSubject<[Int], Error>()
+        let input: [[Int]] = (0...1000).map { _ in
+            (0...Int.random(in: 0...30)).map { _ in Int.random(in: 0...1000) }
+        }
+        
+        let expected = Set(input.flatMap { $0 })
+        
+        let ex1 = expectation(description: "No duplicate events")
+        let ex2 = expectation(description: "No duplicate values")
+        let ex3 = expectation(description: "Expected set equals collected")
+        
+        let sub = subject
+            .distinct()
+            .replaceError(with: [])
+            .collect()
+            .sink { receivedValues in
+                let uniqueReceivedValues = Set(receivedValues)
+                if receivedValues.count == uniqueReceivedValues.count { ex1.fulfill() }
+                else { XCTFail("Received \(receivedValues.count) events, of which only \(uniqueReceivedValues.count) are unique.") }
+        
+                let receivedIntegers = receivedValues.flatMap { $0 }
+                let uniqueReceivedIntegers = Set(receivedIntegers)
+        
+                if receivedIntegers.count == uniqueReceivedIntegers.count { ex2.fulfill() }
+                else { XCTFail("Received \(receivedIntegers.count) values, of which only \(uniqueReceivedIntegers.count) are unique.") }
+        
+                if uniqueReceivedIntegers == expected { ex3.fulfill() }
+                else { XCTFail("Received set of elements does not equal expected.") }
+        }
+        
+        let lastIndex = input.count - 1
+        input.enumerated().forEach { i, v in
+            queue.async {
+                subject.send(v)
+                if i == lastIndex { subject.send(completion: .finished) }
+            }
+        }
+        
+        defer { sub.cancel() }
+        
+        wait(for: [ex1, ex2, ex3], timeout: 15)
+    }
+}

--- a/Tests/CombineExtensionsTests/DistinctTests.swift
+++ b/Tests/CombineExtensionsTests/DistinctTests.swift
@@ -89,7 +89,7 @@ final class DistinctTests: XCTestCase {
         wait(for: [ex], timeout: 2)
     }
     
-    func testDistinctConsecutivenessWithPassThroughSubject() throws {
+    func testDistinctConsecutivenessWithPassthroughSubject() throws {
         let queue = DispatchQueue(label: "global.concurrent.queue", qos: .background, attributes: .concurrent)
         
         let subject = PassthroughSubject<[Int], Error>()
@@ -110,16 +110,16 @@ final class DistinctTests: XCTestCase {
             .sink { receivedValues in
                 let uniqueReceivedValues = Set(receivedValues)
                 if receivedValues.count == uniqueReceivedValues.count { ex1.fulfill() }
-                else { XCTFail("Received \(receivedValues.count) events, of which only \(uniqueReceivedValues.count) are unique.") }
+                else { XCTFail("Received \(receivedValues.count) events, of which only \(uniqueReceivedValues.count) are unique") }
         
                 let receivedIntegers = receivedValues.flatMap { $0 }
                 let uniqueReceivedIntegers = Set(receivedIntegers)
         
                 if receivedIntegers.count == uniqueReceivedIntegers.count { ex2.fulfill() }
-                else { XCTFail("Received \(receivedIntegers.count) values, of which only \(uniqueReceivedIntegers.count) are unique.") }
+                else { XCTFail("Received \(receivedIntegers.count) values, of which only \(uniqueReceivedIntegers.count) are unique") }
         
                 if uniqueReceivedIntegers == expected { ex3.fulfill() }
-                else { XCTFail("Received set of elements does not equal expected.") }
+                else { XCTFail("Received set of elements does not equal expected") }
         }
         
         let lastIndex = input.count - 1
@@ -132,6 +132,6 @@ final class DistinctTests: XCTestCase {
         
         defer { sub.cancel() }
         
-        wait(for: [ex1, ex2, ex3], timeout: 15)
+        wait(for: [ex1, ex2, ex3], timeout: 2)
     }
 }


### PR DESCRIPTION
This `PR` introduces a new `Distinct` publisher. `Distinct` requires `Upstream.Output` value to be an `Array` of `Hashable` elements. Be aware that `Distinct` is also thread-safe since `Combine` guarantees that elements will be in consecutive order, but if you have doubt, please check the corresponding test case.