### PR TITLE
Add Publishers.Distinct(upstream:transformer:)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,19 +1,19 @@
-name: Build
+name: Test
 
-on:
+on: 
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
-  build:
-    name: Build and Test
-    runs-on: macos-latest
+  test:
+    name: Test
+    runs-on: macos-12
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Build
-      run: swift build -v
-    - name: Run tests
-      run: swift test -v
+      - uses: actions/checkout@v2
+      - name Xcode Select
+        run: sudo xcode-select -s /Applications/Xcode_13.4.1.app
+      - name: Build
+        run: swift build -v
+      - name: Test
+        run: swift test -v
+

--- a/Sources/CombineExtensions/Distinct.swift
+++ b/Sources/CombineExtensions/Distinct.swift
@@ -5,33 +5,55 @@ extension Publisher {
     public func distinct<T: Hashable>() -> Publishers.Distinct<Self, T> where Output == Array<T> {
         Publishers.Distinct(upstream: self)
     }
+
+    public func distinct<T, V: Hashable>(
+        using transformer: @escaping (T) -> V
+    ) -> Publishers.Distinct<Self, T> where Output == Array<T> {
+        Publishers.Distinct(upstream: self, transformer: transformer)
+    }
 }
 
 extension Publishers {
-    public struct Distinct<Upstream: Publisher, T: Hashable>: Publisher where Upstream.Output == Array<T> {
+    public struct Distinct<Upstream: Publisher, T>: Publisher where Upstream.Output == Array<T> {
+
         public typealias Output = Upstream.Output
         public typealias Failure = Upstream.Failure
 
         private let upstream: Upstream
+        private let isUnique: (T) -> Bool
 
-        public init(upstream: Upstream) {
+        public init(upstream: Upstream) where T: Hashable {
             self.upstream = upstream
+
+            var alreadySeen = Set<T>()
+            isUnique = { output in
+                guard !alreadySeen.contains(output) else { return false }
+                alreadySeen.insert(output)
+                return true
+            }
+        }
+
+        public init<V: Hashable>(
+            upstream: Upstream,
+            transformer: @escaping (T) -> V
+        ) {
+            self.upstream = upstream
+
+            var alreadySeen = Set<V>()
+            isUnique = { output in
+                let o = transformer(output)
+                guard !alreadySeen.contains(o) else { return false }
+                alreadySeen.insert(o)
+                return true
+            }
         }
 
         public func receive<S: Subscriber>(
             subscriber: S
         ) where Output == S.Input, Failure == S.Failure {
-            var previousValues = Set<T>()
-
             self.upstream
                 .compactMap { (values: Upstream.Output) -> Upstream.Output? in
-                    var newValues: [T] = []
-                    for value in values {
-                        if !previousValues.contains(value) {
-                            previousValues.insert(value)
-                            newValues.append(value)
-                        }
-                    }
+                    let newValues = values.filter(isUnique)
                     return newValues.isEmpty ? nil : newValues
                 }
                 .receive(subscriber: subscriber)

--- a/Tests/CombineExtensionsTests/DistinctTests.swift
+++ b/Tests/CombineExtensionsTests/DistinctTests.swift
@@ -52,9 +52,7 @@ final class DistinctTests: XCTestCase {
             [WWDC(year: 2016), WWDC(year: 2017), WWDC(year: 2015)],
             [WWDC(year: 2015), WWDC(year: 2017), WWDC(year: 2018), WWDC(year: 2014)],
             [WWDC(year: 2014), WWDC(year: 2020), WWDC(year: 2021)],
-        ]
-            .publisher
-            .distinct()
+        ].publisher.distinct()
         
         let expected = [
             [WWDC(year: 2016), WWDC(year: 2017), WWDC(year: 2015)],
@@ -64,6 +62,34 @@ final class DistinctTests: XCTestCase {
         
         let ex = pub.expectOutput(expected)
         
+        wait(for: [ex], timeout: 2)
+    }
+
+    func testDistinctWithTransformer() throws {
+        struct WWDC: Equatable {
+            let id: String
+            let year: Int
+
+            init(_ year: Int) {
+                id = String(year)
+                self.year = year
+            }
+        }
+
+        let pub = [
+            [WWDC(2016), WWDC(2017), WWDC(2015)],
+            [WWDC(2015), WWDC(2017), WWDC(2018), WWDC(2014)],
+            [WWDC(2014), WWDC(2020), WWDC(2021)],
+        ].publisher.distinct(using: { $0.id })
+
+        let expected = [
+            [WWDC(2016), WWDC(2017), WWDC(2015)],
+            [WWDC(2018), WWDC(2014)],
+            [WWDC(2020), WWDC(2021)],
+        ]
+
+        let ex = pub.expectOutput(expected)
+
         wait(for: [ex], timeout: 2)
     }
     


### PR DESCRIPTION
This pull request improves the flexibility of `Publishers.Distinct` by allowing the caller to specify a value to use to unique a type. Only this value is required to conform to `Hashable`. This change is completely backwards compatible.